### PR TITLE
Feat/enhanced chatting with gpt

### DIFF
--- a/src/main/java/org/pandas/bambooclub/domain/chat/service/ChatService.kt
+++ b/src/main/java/org/pandas/bambooclub/domain/chat/service/ChatService.kt
@@ -25,7 +25,7 @@ class ChatService(
     ): ChatResponse {
         saveHumanChat(principal, request)
         val list = chatRepository.findAllByUserIdAndChatRoomIdAndChatType(principal.userId, request.chatRoomId, ChatType.HUMAN)
-        val previousContent = "" // convertPreviousContent(list)
+        val previousContent = convertPreviousContent(list)
         val response = sendMessageToOpenAI(principal, request, previousContent)
         val content: String? = response?.choices?.get(0)?.message?.content ?: ""
         val aiChat = saveAiChat(principal, request, content)
@@ -33,7 +33,8 @@ class ChatService(
     }
 
     private fun convertPreviousContent(list: List<Chat>): String {
-        val result: String = list.joinToString("\n") { it.content ?: "" }
+        val result: String = list.joinToString(" ") { it.content ?: "" }
+        logger.info("content")
         logger.info(result)
         return result
     }

--- a/src/main/java/org/pandas/bambooclub/global/config/OpenAIClient.kt
+++ b/src/main/java/org/pandas/bambooclub/global/config/OpenAIClient.kt
@@ -29,7 +29,7 @@ class OpenAIClient(
         val requestBody =
             """
             {
-                "model": "gpt-3.5-turbo",
+                "model": "gpt-4",
                 "messages": [
                     {
                         "role": "system",


### PR DESCRIPTION
- 전의 메시지들을 같이 context로 제공하려고 붙여서 날리면 open ai 의 api에서 에러가 돌아왔었는데
원인을 파악하고 고쳤습니다


```yaml
private fun convertPreviousContent(list: List<Chat>): String {
        val result: String = list.joinToString(" ") { it.content ?: "" }
        logger.info("content")
        logger.info(result)
        return result
    }
```

전의 메시지들을 보낼때 항상 에러가 돌아왔는데
joinToString으로 연결할때 “\n” 말고 “ “으로 하니까 에러가 사라졌습니다

- 채팅에 사용되는 gpt 모델을 3.5-turbo에서 4로 변경했습니다